### PR TITLE
generate gh-pages automatically

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,16 @@
+name: Build and deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  github-pages:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: helaili/jekyll-action@2.0.4
+        env:
+          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    eventmachine (1.2.7-x64-mingw32)
-    ffi (1.13.1-x64-mingw32)
+    eventmachine (1.2.7)
+    ffi (1.13.1)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.3)
@@ -59,7 +59,7 @@ GEM
     rexml (3.2.4)
     rouge (3.21.0)
     safe_yaml (1.0.5)
-    sassc (2.4.0-x64-mingw32)
+    sassc (2.4.0)
       ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -73,6 +73,7 @@ GEM
 
 PLATFORMS
   x64-mingw32
+  ruby
 
 DEPENDENCIES
   jekyll (~> 4.1.1)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-(Temporary) website for the TU Delft Digital Competence Centre
+# (Temporary) website for the TU Delft Digital Competence Centre
+
+Code to generate website hosted at: https://dcc.tudelft.nl.
+
+A github action is used to generate the gh-pages branch automatically on a push to the master branch.
+
+Note: if you need to generate a new Gemfile.lock and you are working on a Windows platform, please check this issue: https://github.com/helaili/jekyll-action/issues/60


### PR DESCRIPTION
This became necessary when adding CNAME since github.io automatically runs jekyll and the TU Delft doesn't.